### PR TITLE
Add a trailing slash to the permlink for blog posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ pluralizelisttitles = false
 preserveTaxonomyNames = true
 
 [permalinks]
-    blog = "blog/:year/:month/:day/:slug"
+    blog = "blog/:year/:month/:day/:slug/"
 
 [params]
     # Tell me who you are


### PR DESCRIPTION
Fixes rstudio/blogdown#34